### PR TITLE
Dlab 535 and 540 > v2.1-RC2

### DIFF
--- a/infrastructure-provisioning/src/general/conf/dlab.ini
+++ b/infrastructure-provisioning/src/general/conf/dlab.ini
@@ -232,7 +232,7 @@ multiple_clusters = false
 ### R China mirror
 r_mirror = http://mirror.lzu.edu.cn/CRAN/
 ### NVidia driver version for Tensor/DeepLearning notebooks
-nvidia_version = 390.48
+nvidia_version = 418.43
 ### Caffe library version for DeepLearning notebook
 caffe_version = 1.0
 ### Caffe2 library version for DeepLearning notebook

--- a/infrastructure-provisioning/src/general/conf/dlab.ini
+++ b/infrastructure-provisioning/src/general/conf/dlab.ini
@@ -97,7 +97,7 @@ edge_instance_size = t2.medium
 ### Amazon region name for whole dlab provisioning
 region = us-west-2
 ### Amazon ami name based on debian conf_os_family for all dlab instances
-debian_image_name = ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20160907.1
+debian_image_name = ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20190212
 ### Amazon ami name based on RedHat conf_os_family for all dlab instances
 redhat_image_name = RHEL-7.4_HVM-20180103-x86_64-2-Hourly2-GP2
 ### Amazon account ID

--- a/infrastructure-provisioning/src/general/lib/os/debian/common_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/common_lib.py
@@ -41,6 +41,7 @@ def ensure_pkg(user, requisites='linux-headers-generic python-pip python-dev '
             sudo('touch /home/{}/.ensure_dir/pkg_upgraded'.format(user))
             sudo('systemctl enable haveged')
             sudo('systemctl start haveged')
+            sudo('apt-get install --install-recommends linux-aws-hwe')
     except:
         sys.exit(1)
 

--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -282,10 +282,10 @@ def install_tensor(os_user, cuda_version, cuda_file_name,
             sudo('apt-get -y install dkms')
             kernel_version = run('uname -r | tr -d "[..0-9-]"')
             if kernel_version == 'azure':
-                sudo('apt-get -y install linux-modules-extra-`uname -r`')
+                sudo('apt-get -y install linux-modules-`uname -r`')
             else:
                 #legacy support for old kernels
-                sudo('if [[ $(apt-cache search linux-image-extra-`uname -r`) ]]; then apt-get -y install linux-image-extra-`uname -r`; else apt-get -y install linux-modules-extra-`uname -r`; fi;')
+                sudo('if [[ $(apt-cache search linux-image-`uname -r`) ]]; then apt-get -y install linux-image-`uname -r`; else apt-get -y install linux-modules-`uname -r`; fi;')
             sudo('wget http://us.download.nvidia.com/XFree86/Linux-x86_64/{0}/NVIDIA-Linux-x86_64-{0}.run -O /home/{1}/NVIDIA-Linux-x86_64-{0}.run'.format(nvidia_version, os_user))
             sudo('/bin/bash /home/{0}/NVIDIA-Linux-x86_64-{1}.run -s --dkms'.format(os_user, nvidia_version))
             sudo('rm -f /home/{0}/NVIDIA-Linux-x86_64-{1}.run'.format(os_user, nvidia_version))


### PR DESCRIPTION
Fixed the following tickets: [535] SSN creation fails and [540] Notebook creation (based on GPU) fails