### PR TITLE
[DLAB-592] Upgrade Dataproc to 1.2 and 1.4 [bugfix]

### DIFF
--- a/infrastructure-provisioning/src/general/conf/dlab.ini
+++ b/infrastructure-provisioning/src/general/conf/dlab.ini
@@ -222,7 +222,7 @@ jupyter_version = 5.7.4
 ### Version of TensorFlow to be installed on notebook
 tensorflow_version = 1.8.0
 ### Version of Zeppelin to be installed on notebook
-zeppelin_version = 0.8.0
+zeppelin_version = 0.8.1
 ### Version of Rstudio to be installed on notebook
 rstudio_version = 1.1.463
 ### Version of Scala to be installed on notebook

--- a/infrastructure-provisioning/src/general/files/aws/zeppelin_description.json
+++ b/infrastructure-provisioning/src/general/files/aws/zeppelin_description.json
@@ -19,10 +19,10 @@
   "exploratory_environment_versions" :
   [
     {
-      "template_name": "Apache Zeppelin 0.8.0",
+      "template_name": "Apache Zeppelin 0.8.1",
       "description": "Base image with Apache Zeppelin node creation routines",
       "environment_type": "exploratory",
-      "version": "zeppelin-0.8.0",
+      "version": "zeppelin-0.8.1",
       "vendor": "AWS"
     }
   ]

--- a/infrastructure-provisioning/src/general/files/azure/zeppelin_description.json
+++ b/infrastructure-provisioning/src/general/files/azure/zeppelin_description.json
@@ -15,10 +15,10 @@
   "exploratory_environment_versions" :
   [
     {
-      "template_name": "Apache Zeppelin 0.8.0",
+      "template_name": "Apache Zeppelin 0.8.1",
       "description": "Base image with Apache Zeppelin node creation routines",
       "environment_type": "exploratory",
-      "version": "zeppelin-0.8.0",
+      "version": "zeppelin-0.8.1",
       "vendor": "Azure"
     }
   ]

--- a/infrastructure-provisioning/src/general/files/gcp/zeppelin_description.json
+++ b/infrastructure-provisioning/src/general/files/gcp/zeppelin_description.json
@@ -23,10 +23,10 @@
   "exploratory_environment_versions" :
   [
     {
-      "template_name": "Apache Zeppelin 0.8.0",
+      "template_name": "Apache Zeppelin 0.8.1",
       "description": "Base image with Apache Zeppelin node creation routines",
       "environment_type": "exploratory",
-      "version": "zeppelin-0.8.0",
+      "version": "zeppelin-0.8.1",
       "vendor": "GCP"
     }
   ]

--- a/integration-tests/examples/gcp_templates/deeplearning/dataproc.json
+++ b/integration-tests/examples/gcp_templates/deeplearning/dataproc.json
@@ -6,7 +6,7 @@
   "dataproc_preemptible_count": "0",
   "dataproc_master_instance_type" : "n1-standard-2",
   "dataproc_slave_instance_type" : "n1-standard-2",
-  "dataproc_version" : "1.1",
+  "dataproc_version" : "1.2",
   "notebook_name": "set notebook name",
   "template_name" : "Dataproc cluster"
 }

--- a/integration-tests/examples/gcp_templates/jupyter/dataproc.json
+++ b/integration-tests/examples/gcp_templates/jupyter/dataproc.json
@@ -6,7 +6,7 @@
   "dataproc_preemptible_count": "0",
   "dataproc_master_instance_type" : "n1-standard-2",
   "dataproc_slave_instance_type" : "n1-standard-2",
-  "dataproc_version" : "1.1",
+  "dataproc_version" : "1.2",
   "notebook_name": "set notebook name",
   "template_name" : "Dataproc cluster"
 }

--- a/integration-tests/examples/gcp_templates/rstudio/dataproc.json
+++ b/integration-tests/examples/gcp_templates/rstudio/dataproc.json
@@ -6,7 +6,7 @@
   "dataproc_preemptible_count": "0",
   "dataproc_master_instance_type" : "n1-standard-2",
   "dataproc_slave_instance_type" : "n1-standard-2",
-  "dataproc_version" : "1.1",
+  "dataproc_version" : "1.2",
   "notebook_name": "set notebook name",
   "template_name" : "Dataproc cluster"
 }

--- a/integration-tests/examples/gcp_templates/tensor/dataproc.json
+++ b/integration-tests/examples/gcp_templates/tensor/dataproc.json
@@ -6,7 +6,7 @@
   "dataproc_preemptible_count": "0",
   "dataproc_master_instance_type" : "n1-standard-2",
   "dataproc_slave_instance_type" : "n1-standard-2",
-  "dataproc_version" : "1.1",
+  "dataproc_version" : "1.2",
   "notebook_name": "set notebook name",
   "template_name" : "Dataproc cluster"
 }

--- a/integration-tests/examples/gcp_templates/zeppelin/dataproc.json
+++ b/integration-tests/examples/gcp_templates/zeppelin/dataproc.json
@@ -6,7 +6,7 @@
   "dataproc_preemptible_count": "0",
   "dataproc_master_instance_type" : "n1-standard-2",
   "dataproc_slave_instance_type" : "n1-standard-2",
-  "dataproc_version" : "1.1",
+  "dataproc_version" : "1.2",
   "notebook_name": "set notebook name",
   "template_name" : "Dataproc cluster"
 }


### PR DESCRIPTION
 - update Zeppelin from 0.8.0 to 0.8.1 for Spark 2.4.0 support
 - change autotest Dataproc version to 1.2 from 1.1