### PR TITLE
DLAB-1087 and DLAB-1084 fixes

### DIFF
--- a/infrastructure-provisioning/src/general/lib/os/debian/common_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/common_lib.py
@@ -33,17 +33,30 @@ def ensure_pkg(user, requisites='linux-headers-generic python-pip python-dev '
                                 'libffi-dev unzip libxml2-dev haveged'):
     try:
         if not exists('/home/{}/.ensure_dir/pkg_upgraded'.format(user)):
-            print("Updating repositories "
-                  "and installing requested tools: {}".format(requisites))
-            sudo('apt-get update')
-            sudo('apt-get -y install ' + requisites)
-            sudo('unattended-upgrades -v')
-            sudo('export LC_ALL=C')
-            sudo('touch /home/{}/.ensure_dir/pkg_upgraded'.format(user))
-            sudo('systemctl enable haveged')
-            sudo('systemctl start haveged')
-            if os.environ['conf_cloud_provider'] == 'aws':
-                sudo('apt-get -y install --install-recommends linux-aws-hwe')
+            count = 0
+            check = False
+            while not check:
+                if count > 60:
+                    print("Repositories are not available. Please, try again later.")
+                    sys.exit(1)
+                else:
+                    try:
+                        print("Updating repositories "
+                                "and installing requested tools: {}".format(requisites))
+                        print("Attempt number " + str(count) + " to install requested tools. Max 60 tries.")
+                        sudo('apt-get update')
+                        sudo('apt-get -y install ' + requisites)
+                        sudo('unattended-upgrades -v')
+                        sudo('export LC_ALL=C')
+                        sudo('touch /home/{}/.ensure_dir/pkg_upgraded'.format(user))
+                        sudo('systemctl enable haveged')
+                        sudo('systemctl start haveged')
+                        if os.environ['conf_cloud_provider'] == 'aws':
+                            sudo('apt-get -y install --install-recommends linux-aws-hwe')
+                        check = True
+                    except:
+                        count += 1
+                        time.sleep(50)
     except:
         sys.exit(1)
 

--- a/infrastructure-provisioning/src/general/scripts/aws/tensor-rstudio_configure.py
+++ b/infrastructure-provisioning/src/general/scripts/aws/tensor-rstudio_configure.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
 
     # generating variables regarding EDGE proxy on Notebook instance
     instance_hostname = get_instance_hostname(notebook_config['tag_name'], notebook_config['instance_name'])
-    edge_instance_name = conf_service_base_name + "-" + os.environ['project_name'] + '-edge'
+    edge_instance_name = notebook_config['service_base_name'] + "-" + os.environ['project_name'] + '-edge'
     edge_instance_hostname = get_instance_hostname(notebook_config['tag_name'], edge_instance_name)
     edge_instance_private_ip = get_instance_ip_address(notebook_config['tag_name'], edge_instance_name).get('Private')
     if notebook_config['network_type'] == 'private':


### PR DESCRIPTION
DLAB-1087 - [AWS]: RStudio with TensorFlow creation fails due to 'conf_service_base_name' is not defined fixed
DLAB-1084 - [Debian]: Notebook/spark cluster creations stuck using shared image