### PR TITLE
[DLAB-1656]: [GCP][RStudio]: Remote kernel is still available in the list after Data Engine termination

### DIFF
--- a/infrastructure-provisioning/src/general/lib/gcp/actions_lib.py
+++ b/infrastructure-provisioning/src/general/lib/gcp/actions_lib.py
@@ -1406,6 +1406,7 @@ def configure_local_spark(jars_dir, templates_dir, memory_type='driver'):
 
 def remove_dataengine_kernels(notebook_name, os_user, key_path, cluster_name):
     try:
+        computational_name = os.environ['computational_name'].replace('_', '-').lower()
         private = meta_lib.get_instance_private_ip_address(cluster_name, notebook_name)
         env.hosts = "{}".format(private)
         env.user = "{}".format(os_user)
@@ -1454,7 +1455,7 @@ def remove_dataengine_kernels(notebook_name, os_user, key_path, cluster_name):
             sudo('sleep 5')
             sudo('rm -rf /home/{}/.ensure_dir/dataengine_{}_interpreter_ensured'.format(os_user, cluster_name))
         if exists('/home/{}/.ensure_dir/rstudio_dataengine_ensured'.format(os_user)):
-            dlab.fab.remove_rstudio_dataengines_kernel(os.environ['computational_name'], os_user)
+            dlab.fab.remove_rstudio_dataengines_kernel(computational_name, os_user)
         sudo('rm -rf  /opt/' + cluster_name + '/')
         print("Notebook's {} kernels were removed".format(env.hosts))
     except Exception as err:


### PR DESCRIPTION
fixed remote spark kernel removal for computational name that contains upper-case