### PR TITLE
[DLAB-1961]: Show error message if user tryes update/downgrade library by unreal  version

### DIFF
--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -396,7 +396,7 @@ def install_os_pkg(requisites):
             sudo('apt list --installed | if ! grep {0}/ > /tmp/os_install_{1}.list; then  echo "" > /tmp/os_install_{1}.list;fi'.format(os_pkg.split("=")[0], os_pkg))
             res = sudo('cat /tmp/os_install_{}.list'.format(os_pkg))
             if err:
-                status_msg = 'failed'
+                status_msg = 'installation_error'
             elif res:
                 ansi_escape = re.compile(r'\x1b[^m]*m')
                 ver = ansi_escape.sub('', res).split("\r\n")

--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -395,7 +395,7 @@ def install_os_pkg(requisites):
             if 'E: Version' in err and 'was not found' in err:
                 versions = sudo ('apt-cache policy {} | grep 500 | grep -v Packages'.format(os_pkg.split("=")[0])).replace('\r\n', '').replace(' 500', '').replace('     ', ' ').strip().split(' ')
                 if versions != '':
-                    status_msg = 'invalid version'
+                    status_msg = 'invalid_version'
             else:
                 versions = []
                 status_msg = 'failed'

--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -372,8 +372,10 @@ def install_os_pkg(requisites):
         manage_pkg('update', 'remote', '')
         for os_pkg in requisites:
             if os_pkg[1] != '' and os_pkg[1] !='N/A':
+                version = os_pkg[1]
                 os_pkg = "{}={}".format(os_pkg[0], os_pkg[1])
             else:
+                version = ''
                 os_pkg = os_pkg[0]
             sudo('DEBIAN_FRONTEND=noninteractive apt-get -y install --allow-downgrades {0} 2>&1 | tee /tmp/tee.tmp; if ! grep -w -E "({1})" /tmp/tee.tmp > '
                  '/tmp/os_install_{0}.log; then echo "" > /tmp/os_install_{0}.log;fi'.format(os_pkg, error_parser))
@@ -399,12 +401,11 @@ def install_os_pkg(requisites):
                 status_msg = 'failed'
             sudo('apt list --installed | if ! grep {0}/ > /tmp/os_install_{1}.list; then  echo "" > /tmp/os_install_{1}.list;fi'.format(os_pkg.split("=")[0], os_pkg))
             res = sudo('cat /tmp/os_install_{}.list'.format(os_pkg))
-            version = os_pkg.split("=")[1]
             if res:
                 ansi_escape = re.compile(r'\x1b[^m]*m')
                 ver = ansi_escape.sub('', res).split("\r\n")
                 version = [i for i in ver if os_pkg.split("=")[0] in i][0].split(' ')[1]
-                if os_pkg.split("=")[1] == '' or os_pkg.split("=")[1] == version:
+                if '=' in os_pkg and os_pkg.split("=")[1] == version or True:
                     status_msg = "installed"
             status.append({"group": "os_pkg", "name": os_pkg.split("=")[0], "version": version, "status": status_msg,
                            "error_message": err, "add_pkgs": dep, "available_versions": versions})

--- a/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
+++ b/infrastructure-provisioning/src/general/lib/os/debian/notebook_lib.py
@@ -375,7 +375,7 @@ def install_os_pkg(requisites):
                 version = os_pkg[1]
                 os_pkg = "{}={}".format(os_pkg[0], os_pkg[1])
             else:
-                version = ''
+                version = 'N/A'
                 os_pkg = os_pkg[0]
             sudo('DEBIAN_FRONTEND=noninteractive apt-get -y install --allow-downgrades {0} 2>&1 | tee /tmp/tee.tmp; if ! grep -w -E "({1})" /tmp/tee.tmp > '
                  '/tmp/os_install_{0}.log; then echo "" > /tmp/os_install_{0}.log;fi'.format(os_pkg, error_parser))

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -98,6 +98,9 @@ def install_pip_pkg(requisites, pip_version, lib_group):
                 if versions != '':
                     versions = versions.split(', ')
                     status_msg = 'invalid version'
+                else:
+                    versions = []
+
             sudo('if ! grep -w -i -E  "Installing collected packages:" /tmp/tee.tmp > /tmp/{0}install_{1}.log; '
                  'then  echo "" > /tmp/{0}install_{1}.log;fi'.format(pip_version, pip_pkg))
             dep = sudo('cat /tmp/{0}install_{1}.log'.format(pip_version, pip_pkg)).replace('\r\n', '').strip()[31:]

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -96,7 +96,7 @@ def install_pip_pkg(requisites, pip_version, lib_group):
                 versions = err[err.find("(from versions: ") + 16: err.find(")\r\n")]
                 if versions != '':
                     versions = versions.split(', ')
-                    status_msg = 'invalid version'
+                    status_msg = 'invalid_version'
                 else:
                     versions = []
 
@@ -452,7 +452,7 @@ def install_r_pkg(requisites):
                 sudo('R -e \'install.packages("versions", repos="https://cloud.r-project.org", dep=TRUE)\'')
                 versions = sudo('R -e \'library(versions); available.versions("' + name + '")\' 2>&1 | grep -A 50 '
                                     '\'date available\' | awk \'{print $2}\'').replace('\r\n', ' ')[5:].split(' ')
-                status_msg = 'invalid version'
+                status_msg = 'invalid_version'
             else:
                 versions = []
             status.append({"group": "r_pkg", "name": name, "version": version, "status": status_msg, "error_message": err, "available_versions": versions, "add_pkgs": dep})

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -88,7 +88,6 @@ def install_pip_pkg(requisites, pip_version, lib_group):
                 else:
                     version = \
                     [i for i in ver if pip_pkg.split("==")[0].lower() in i][0].split('==')[1]
-                if "==" in pip_pkg and pip_pkg.split("==")[1] == version or True:
                     status_msg = "installed"
             else:
                 status_msg = 'failed'
@@ -420,6 +419,7 @@ def install_r_pkg(requisites):
     try:
         for r_pkg in requisites:
             name, vers = r_pkg
+            version = vers
             if vers =='N/A':
                 vers = ''
             else:
@@ -445,17 +445,17 @@ def install_r_pkg(requisites):
             if res:
                 ansi_escape = re.compile(r'\x1b[^m]*m')
                 version = ansi_escape.sub('', res).split("\r\n")[0].split('"')[1]
-                status.append({"group": "r_pkg", "name": name, "version": version, "status": "installed", "add_pkgs": dep})
+                status_msg = 'installed'
             else:
-                if 'Error in download_version_url(package, version, repos, type) :' in err:
-                    sudo('R -e \'install.packages("versions", repos="https://cloud.r-project.org", dep=TRUE)\'')
-                    versions = sudo('R -e \'library(versions); available.versions("' + name + '")\' 2>&1 | grep -A 50 '
+                status_msg = 'failed'
+            if 'Error in download_version_url(package, version, repos, type) :' in err:
+                sudo('R -e \'install.packages("versions", repos="https://cloud.r-project.org", dep=TRUE)\'')
+                versions = sudo('R -e \'library(versions); available.versions("' + name + '")\' 2>&1 | grep -A 50 '
                                     '\'date available\' | awk \'{print $2}\'').replace('\r\n', ' ')[5:].split(' ')
-                    status_msg = 'invalid version'
-                else:
-                    versions = []
-                    status_msg = 'failed'
-                status.append({"group": "r_pkg", "name": name, "status": status_msg, "error_message": err, "available_versions": versions})
+                status_msg = 'invalid version'
+            else:
+                versions = []
+            status.append({"group": "r_pkg", "name": name, "version": version, "status": status_msg, "error_message": err, "available_versions": versions, "add_pkgs": dep})
         return status
     except Exception as err:
         append_result("Failed to install R packages", str(err))

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -64,7 +64,7 @@ def install_pip_pkg(requisites, pip_version, lib_group):
         for pip_pkg in requisites:
             if pip_pkg[1] == '' or pip_pkg[1] == 'N/A':
                 pip_pkg = pip_pkg[0]
-                version = ''
+                version = 'N/A'
             else:
                 version = pip_pkg[1]
                 pip_pkg = "{}=={}".format(pip_pkg[0], pip_pkg[1])

--- a/infrastructure-provisioning/src/general/lib/os/fab.py
+++ b/infrastructure-provisioning/src/general/lib/os/fab.py
@@ -80,7 +80,7 @@ def install_pip_pkg(requisites, pip_version, lib_group):
                      '/tmp/{0}install_{1}.list;fi'.format(pip_version, changed_pip_pkg))
                 res = sudo('cat /tmp/{0}install_{1}.list'.format(pip_version, changed_pip_pkg))
             if err:
-                status_msg = 'failed'
+                status_msg = 'installation_error'
             elif res:
                 res = res.lower()
                 ansi_escape = re.compile(r'\x1b[^m]*m')
@@ -443,7 +443,7 @@ def install_r_pkg(requisites):
             sudo('R -e \'installed.packages()[,c(3:4)]\' | if ! grep -w {0} > /tmp/install_{0}.list; then  echo "" > /tmp/install_{0}.list;fi'.format(name))
             res = sudo('cat /tmp/install_{0}.list'.format(name))
             if err:
-                status_msg = 'failed'
+                status_msg = 'installation_error'
             elif res:
                 ansi_escape = re.compile(r'\x1b[^m]*m')
                 version = ansi_escape.sub('', res).split("\r\n")[0].split('"')[1]

--- a/infrastructure-provisioning/src/general/scripts/os/install_additional_libs.py
+++ b/infrastructure-provisioning/src/general/scripts/os/install_additional_libs.py
@@ -97,12 +97,16 @@ if __name__ == "__main__":
     try:
         print('Installing other packages: {}'.format(pkgs['libraries']['others']))
         for pkg in pkgs['libraries']['others']:
-            status_pip2 = install_pip_pkg([pkg], 'pip2', 'others')
-            status_pip3 = install_pip_pkg([pkg], 'pip3', 'others')
-            if status_pip2[0]['status'] == 'installed':
-                general_status = general_status + status_pip2
-            else:
+            if os.environ['conf_resource'] in ('dataengine-service'):#, 'dataengine'):
+                status_pip3 = install_pip_pkg([pkg], 'pip3', 'others')
                 general_status = general_status + status_pip3
+            else:
+                status_pip2 = install_pip_pkg([pkg], 'pip2', 'others')
+                status_pip3 = install_pip_pkg([pkg], 'pip3', 'others')
+                if status_pip2[0]['status'] == 'installed':
+                    general_status = general_status + status_pip2
+                else:
+                    general_status = general_status + status_pip3
     except KeyError:
         pass
 


### PR DESCRIPTION
- If user installs already installed library but indicates fiction version, the output will be 'invalid version'

- If any distributive is not available for some library show as library installation 'Failed' and convey error message which we have previously

- If there is another error during installation except for 'No matching distribution found' show the status 'failed' and convey the particular error

- If library is failed convey which dependencies have been installed during installation  added dependencies to responce with failed status, probably some changes should be made on front-end to show dependency list with error message 

It's impossible to install any library from r package for Dataproc. **not ready yet**