### PR TITLE
[DLAB-2034]: Project creation fails for external endpoint on GCP

### DIFF
--- a/infrastructure-provisioning/terraform/gcp/endpoint/main/variables.tf
+++ b/infrastructure-provisioning/terraform/gcp/endpoint/main/variables.tf
@@ -113,7 +113,10 @@ variable "endpoint_policies" {
     "compute.projects.setCommonInstanceMetadata",
     "compute.projects.setDefaultServiceAccount",
     "compute.subnetworks.create",
-    "compute.subnetworks.delete"
+    "compute.subnetworks.delete",
+    "compute.routes.create",
+    "compute.routes.delete",
+    "compute.routes.get"
   ]
 }
 


### PR DESCRIPTION
added compute.routes.create, compute.routes.delete, compute.routes.get permissions for gcp external endpiont`s service account